### PR TITLE
Release 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefecthq/vue-charts",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "keywords": [
     "vue3",

--- a/src/Base.ts
+++ b/src/Base.ts
@@ -43,7 +43,7 @@ export interface IBaseOptions {
 }
 
 // Starting these with an underscore allows us to use UUIDs as HTMLElement ids
-const _uid = () => `_${crypto.randomUUID()}`
+const _uid = () => `_${crypto?.randomUUID?.() || (crypto?.getRandomValues?.(new Uint32Array(1))[0] || new Date().getTime()) * Math.pow(2, -32) * 16}`
 
 
 export class Base implements IBase {


### PR DESCRIPTION
This PR releases v0.0.6 of the package, which includes a fix for generating UUIDs in Safari, which doesn't yet support the `crypto.randomUUID()` package. In its place we generate pseudo-random UUIDs using `crypto.getRandomValues` on a Uint32Array`. 