### PR TITLE
Tweaks for ScatterPlot

### DIFF
--- a/src/components/ScatterPlot.vue
+++ b/src/components/ScatterPlot.vue
@@ -193,7 +193,7 @@
     const [min, max] = yScale.value.domain()
     const stepValue = (max - min) / (props.yTicks - 1)
     const tickValues = d3.range(min, max + stepValue, stepValue)
-    
+
     return tickValues
   }
 


### PR DESCRIPTION
This PR introduces tweaks to the yScale of the ScatterPlot. After conversation with @pleek91 and @jlowin we decided that scatterPlot looks better with fewer ticks on the Y scale (5 to be specific) and set a goal to minimize white space/make scatterPlot more informative. 

This particular PR updates the domain of yScale to render dots in the range between 0 and the duration of the topmost dot. For situations when the duration of the run is less than 1s, we set the top of the domain to be `top = Math.max(top, 1)`. The same variable also ensures the rendering of a nice-looking empty scatterPlot when we don't have any runs. 

To control the number of ticks on the Y scale and to make it flexible, we introduce `getYTicks()` function which renders the number of ticks set by the prop `yTicks` (default 5). The feature of the update that when the run is longer than 1s, the topmost run like a cherry on top will be the last dot on top 😅

Examples with Nebula UI:
**Empty scatterPlot**
<img width="700" alt="Screen Shot 2022-07-28 at 4 22 47 PM" src="https://user-images.githubusercontent.com/40467112/181630385-35723487-9486-4150-b193-978804cb7f2c.png">

**ScatterPlot with runs that are less than 1s**
<img width="700" alt="Screen Shot 2022-07-28 at 4 22 37 PM" src="https://user-images.githubusercontent.com/40467112/181630503-d2e140d6-d7bc-4028-bebe-7f7d14ab403d.png">

**Scatterplot with runs longer than 1s** 
<img width="700" alt="Screen Shot 2022-07-28 at 4 22 56 PM" src="https://user-images.githubusercontent.com/40467112/181630698-d8a30b97-d1d8-46a9-8bdb-05e89e3631ff.png">

PS: [orion-design visual changes](https://github.com/PrefectHQ/orion-design/pull/452) for the scatterPlot. No more borders!