### PR TITLE
Repair tick formatting of YScale

### DIFF
--- a/src/components/ScatterPlot.vue
+++ b/src/components/ScatterPlot.vue
@@ -45,7 +45,7 @@
     endDate: null,
     dotDiameter: 14,
     chartPadding: () => {
-      return { top: 16, left: 60, bottom: 48, right: 0 }
+      return { top: 16, left: 40, bottom: 48, right: 0 }
     },
   })
 

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -182,22 +182,14 @@ function secondsToApproximateString(input: number, showOnes = true): string {
   const second = intervalStringSecondsIntervalTypeShort('s', seconds, showOnes)
 
   switch (true) {
-    case years > 0 && days == 0:
+    case years > 0:
       return year
-    case years > 0 && days > 0:
-      return `${year } ${ day}`
-    case days > 0 && hours == 0:
+    case days > 0:
       return day
-    case days > 0 && hours > 0:
-      return `${day } ${ hour}`
-    case hours > 0 && minutes == 0:
-      return `${hour } ${ minute}`
-    case hours > 0 && minutes > 0:
-      return `${hour } ${ minute}`
-    case minutes > 0 && seconds == 0:
+    case hours > 0:
+      return hour
+    case minutes > 0:
       return minute
-    case minutes > 0 && seconds > 0:
-      return `${minute } ${ second}`
     default:
       return second
   }


### PR DESCRIPTION
The issue – yScale tick formatting didn't have the proper format and was cut out:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/40467112/182396464-30fc9c61-bcf5-4d5c-a818-5724b62e8266.png">

The fix is bringing over the function from orion-design (o-d is not a dependency of vue charts), the same function that is used in pop-over cards to format duration there

<img width="700" alt="Screen Shot 2022-08-02 at 9 50 02 AM" src="https://user-images.githubusercontent.com/40467112/182397839-297ea69d-276d-4b17-b156-b311963da6da.png">

<img width="700" alt="Screen Shot 2022-08-02 at 11 17 25 AM" src="https://user-images.githubusercontent.com/40467112/182410503-5c94dc5d-e375-40d0-bc2d-0984fbbde189.png">
