### PR TITLE
chore: updated randomId method like orion-design

### DIFF
--- a/src/components/Base.ts
+++ b/src/components/Base.ts
@@ -42,18 +42,43 @@ export interface IBaseOptions {
   },
 }
 
-// typescript says crypto will be defined but it might not be
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-if (crypto && !('randomUUID' in crypto)) {
-  crypto.randomUUID = () => (+[1e7] + -1e3 + -4e3 + -8e3 + -1e11)
+function randomId(): string {
+  // typescript says crypto will be defined but it might not be
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!crypto) {
+    return nonCryptoUUID()
+  }
+
+  // typescript says crypto will be defined but it might not be
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!crypto.randomUUID) {
+    return backupRandomUUID()
+  }
+
+  return crypto.randomUUID()
+}
+
+function backupRandomUUID(): string {
+  return (+[1e7] + -1e3 + -4e3 + -8e3 + -1e11)
     .toString()
     .replace(/[018]/g,
       substring => (+substring ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +substring / 4).toString(16),
     )
 }
 
+function nonCryptoUUID(): string {
+  const first = base16Integer()
+  const last = base16Integer()
+  return `${first.slice(0, 8) }-${ first.slice(8, 12) }-4${ first.slice(13) }-a${ last.slice(1, 4) }-${ last.slice(4)}`
+}
+
+function base16Integer(): string {
+  // eslint-disable-next-line no-loss-of-precision, @typescript-eslint/no-loss-of-precision
+  return `00000000000000000${ (Math.random() * 0xffffffffffffffff).toString(16)}`.slice(-16)
+}
+
 // Starting these with "chart-" allows us to use UUIDs as HTMLElement ids
-const _uid = (): string => `chart-${crypto.randomUUID()}`
+const _uid = (): string => `chart-${randomId()}`
 
 
 export class Base implements IBase {


### PR DESCRIPTION
similar to orion-design, we need to make sure we allow for `crypto` itself to not be defined (running into errors trying to run playwright tests)