### PR TITLE
Feature: Resizing of histogram selection

### DIFF
--- a/demo/views/HistogramChartSection.vue
+++ b/demo/views/HistogramChartSection.vue
@@ -28,7 +28,7 @@
         v-bind="{ data, smooth }"
         v-model:selection-start="selectionStart"
         v-model:selection-end="selectionEnd"
-        :options="{ showXAxis, showYAxis, selectionMinimumSeconds }"
+        :options="{ showXAxis, showYAxis, selectionMinimumSeconds, selectionMaximumSeconds }"
       />
       <p-key-value label="Selection Start" :value="selectionStart" />
       <p-key-value label="Selection End" :value="selectionEnd" />
@@ -54,6 +54,7 @@
   const selectionEnd = ref(end.value)
   const selectionStart = ref(subDays(selectionEnd.value, 1))
   const selectionMinimumSeconds = hoursToSeconds(6)
+  const selectionMaximumSeconds = hoursToSeconds(24)
 
   const data = ref<HistogramData>([])
 

--- a/src/components/HistogramChart/HistogramChart.vue
+++ b/src/components/HistogramChart/HistogramChart.vue
@@ -57,7 +57,7 @@
   import { Pixels } from '@prefecthq/prefect-design'
   import { useElementRect } from '@prefecthq/vue-compositions'
   import * as d3 from 'd3'
-  import { addHours, addSeconds, differenceInSeconds, format, isAfter, isBefore, subHours, subSeconds } from 'date-fns'
+  import { addSeconds, differenceInSeconds, format, isAfter, isBefore, subSeconds } from 'date-fns'
   import { computed, onMounted, ref, watch, watchEffect } from 'vue'
   import { HistogramChartOptions, HistogramData, HistogramDataPoint } from '@/components/HistogramChart'
   import { roundUpToIncrement } from '@/utilities/roundUpToIncrement'
@@ -92,6 +92,7 @@
   const transitionDuration = computed(() => props.options?.transitionDuration ?? 250)
   const transitionDurationString = computed(() => `${transitionDuration.value}ms`)
   const selectionMinimumSeconds = computed(() => props.options?.selectionMinimumSeconds ?? 0)
+  const selectionMaximumSeconds = computed(() => props.options?.selectionMaximumSeconds ?? Infinity)
   const showBars = computed(() => !props.smooth)
   const showSmooth = computed(() => props.smooth)
   const showSelection = computed(() => props.selectionEnd && props.selectionStart)
@@ -359,6 +360,12 @@
       selectionStart = minIntervalStart.value
     }
 
+    const maximum = subSeconds(props.selectionEnd!, selectionMaximumSeconds.value)
+
+    if (isBefore(selectionStart, maximum)) {
+      selectionStart = maximum
+    }
+
     const minimum = subSeconds(props.selectionEnd!, selectionMinimumSeconds.value)
 
     if (isAfter(selectionStart, minimum)) {
@@ -380,6 +387,12 @@
 
     if (isAfter(selectionEnd, maxIntervalEnd.value)) {
       selectionEnd = maxIntervalEnd.value
+    }
+
+    const maximum = addSeconds(props.selectionStart!, selectionMaximumSeconds.value)
+
+    if (isAfter(selectionEnd, maximum)) {
+      selectionEnd = maximum
     }
 
     const minimum = addSeconds(props.selectionStart!, selectionMinimumSeconds.value)

--- a/src/components/HistogramChart/types.ts
+++ b/src/components/HistogramChart/types.ts
@@ -15,4 +15,5 @@ export type HistogramChartOptions = {
   transition?: boolean,
   transitionDuration?: number,
   selectionMinimumSeconds?: number,
+  selectionMaximumSeconds?: number,
 }


### PR DESCRIPTION
# Description
Allows the user to drag the handles on the left and right sides of the selection window to resize the selection. A minimum and maximum selection can be set to prevent the user from selecting values to big or too small. 

https://www.loom.com/share/e5abce0e94304002bb0b428fac8e4be0