### PR TITLE
Enhancement: Fix line chart fill when data doesn't match startDate or endDate

### DIFF
--- a/src/components/LineChart/LineChart.vue
+++ b/src/components/LineChart/LineChart.vue
@@ -121,8 +121,10 @@
 
   const fillPath = computed<string>(() => {
     const [min, max] = xScale.value.range()
-    const bottomRight = `L ${max},${chartHeight.value}`
-    const bottomLeft = `L ${min},${chartHeight.value}`
+    const [first] = positions.value.at(0) ?? [min]
+    const [last] = positions.value.at(-1) ?? [max]
+    const bottomRight = `L ${last},${chartHeight.value}`
+    const bottomLeft = `L ${first},${chartHeight.value}`
 
     return `${strokePath.value}${bottomRight}${bottomLeft}Z`
   })


### PR DESCRIPTION
# Description

Before
![image](https://user-images.githubusercontent.com/6200442/227374955-58b2f6e6-8ee7-450c-943f-d3a96a96d966.png)

After
![image](https://user-images.githubusercontent.com/6200442/227375030-8575ac39-5091-4798-9090-88c910a87b0d.png)
