### PR TITLE
Enhancement: LineChart & MiniHistogram - Invert colors for light/dark mode

### DIFF
--- a/src/components/LineChart/LineChart.vue
+++ b/src/components/LineChart/LineChart.vue
@@ -142,14 +142,26 @@
 }
 
 .line-chart__path--0 {
-  stop-color: theme('colors.prefect.700')
+  stop-color: theme('colors.sky.300')
 }
 
 .line-chart__path--85 {
-  stop-color: theme('colors.prefect.400')
+  stop-color: theme('colors.sky.600')
 }
 
 .line-chart__path--100 {
+  stop-color: theme('colors.prefect.700')
+}
+
+.dark .line-chart__path--0 {
+  stop-color: theme('colors.prefect.700')
+}
+
+.dark .line-chart__path--85 {
+  stop-color: theme('colors.prefect.400')
+}
+
+.dark .line-chart__path--100 {
   stop-color: theme('colors.sky.300')
 }
 

--- a/src/components/LineChart/LineChart.vue
+++ b/src/components/LineChart/LineChart.vue
@@ -133,6 +133,9 @@
 <style>
 .line-chart {
   min-height: 100px;
+  --darkest: var(--vc-line-chart-color-darkest, theme('colors.prefect.700'));
+  --dark: var(--vc-line-chart-color-dark, theme('colors.prefect.400'));
+  --light: var(--vc-line-chart-color-dark, theme('colors.sky.300'));
 }
 
 .line-chart__path { @apply
@@ -174,6 +177,11 @@
   stop-opacity: 0;
 }
 
+.dark .line-chart__gradient-stop {
+  stop-opacity: 0.3;
+  stop-color: theme('colors.prefect.500');
+}
+
 .line-chart__gradient-start {
   stop-color: #fff;
   stop-opacity: 0;
@@ -181,6 +189,6 @@
 
 .line-chart__gradient-stop {
   stop-opacity: 0.3;
-  stop-color: theme('colors.prefect.500');
+  stop-color: theme('colors.prefect.300');
 }
 </style>

--- a/src/components/MiniHistogram/MiniHistogram.vue
+++ b/src/components/MiniHistogram/MiniHistogram.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { toPixels } from '@prefecthq/prefect-design'
+  import { toPixels, useColorTheme } from '@prefecthq/prefect-design'
   import { useElementRect } from '@prefecthq/vue-compositions'
   import { scaleTime, scaleLinear } from 'd3'
   import { computed, ref } from 'vue'
@@ -24,6 +24,8 @@
     options?: MiniHistogramOptions,
   }>()
 
+  const { value: theme } = useColorTheme()
+
   const chart = ref<Element>()
   const { width: chartWidth } = useElementRect(chart)
 
@@ -31,8 +33,8 @@
   const bars = computed(() => data.value.map(point => getBar(point)))
 
   const options = computed<OptionsWithDefaultValues>(() => ({
-    colorStart: '#034efc',
-    colorEnd: '#7dd3fc',
+    colorStart: '#7dd3fc',
+    colorEnd: '#034efc',
     ...props.options,
   }))
 
@@ -85,10 +87,15 @@
 
   const yScale = computed(() => {
     const scale = scaleLinear()
+    const range = [options.value.colorStart, options.value.colorEnd]
+
+    if (theme.value === 'dark') {
+      range.reverse()
+    }
 
     scale.domain([minValue.value, maxValue.value])
     // @ts-expect-error @types/d3 has an incorrect type for scale. It only accepts numbers but it should also accept strings
-    scale.range([options.value.colorStart, options.value.colorEnd])
+    scale.range(range)
 
     return scale
   })


### PR DESCRIPTION
# Description
inverts the colors on the LineChart and MiniHistogram depending on the color theme. So dark looks same as it did before but on light mode the colors are inverted. This means on both color modes the higher the contrast the higher the value being represented. 

## Line Chart
Dark
![image](https://user-images.githubusercontent.com/6200442/230207049-572eb3af-9fc4-4ed6-9f3a-4fdf6a4876c1.png)
Light
![image](https://user-images.githubusercontent.com/6200442/230207121-d544815f-f01f-4ace-beca-a103922c8536.png)
Light (before)
![image](https://user-images.githubusercontent.com/6200442/230207197-b0f87763-3746-401e-bbf3-1c646f3168ee.png)

## Mini Histogram
This is hard to make screenshots for with the demo because the random data makes comparing difficult. Viewing the preview on this PR and switching between light and dark will show the different well. 
