### PR TITLE
ability to click bars on the mini histogram

### DIFF
--- a/demo/views/MiniHistogramSection.vue
+++ b/demo/views/MiniHistogramSection.vue
@@ -1,6 +1,11 @@
 <template>
-  <ComponentPage title="Mini Histogram">
-    <MiniHistogram :data="data" />
+  <ComponentPage title="Mini Histogram" :demos="demos">
+    <template #basic>
+      <MiniHistogram :data="data" />
+    </template>
+    <template #with-clickable-bars>
+      <MiniHistogram :data="data" :options="{ clickable: true }" @bar-click="onBarClick" />
+    </template>
   </ComponentPage>
 </template>
 
@@ -10,6 +15,7 @@
   import { computed, ref } from 'vue'
   import ComponentPage from '../components/ComponentPage.vue'
   import { generateBarChartData } from '../data'
+  import { MiniHistogramBar } from '@/components'
   import MiniHistogram from '@/components/MiniHistogram/MiniHistogram.vue'
 
   const today = new Date()
@@ -26,4 +32,13 @@
 
     return items
   })
+
+  const demos = [
+    { title: 'Basic' },
+    { title: 'With clickable bars' },
+  ]
+
+  function onBarClick(bar: MiniHistogramBar): void {
+    console.log('Clicked bar:', bar)
+  }
 </script>

--- a/src/components/MiniHistogram/MiniHistogram.vue
+++ b/src/components/MiniHistogram/MiniHistogram.vue
@@ -1,8 +1,13 @@
 <template>
-  <div ref="chart" class="mini-histogram">
+  <div ref="chart" class="mini-histogram" :class="classes.root">
     <template v-for="bar in bars" :key="bar.intervalStart.getTime()">
       <slot name="bar" v-bind="bar">
-        <div class="mini-histogram__bar" :style="bar.styles" />
+        <div
+          class="mini-histogram__bar"
+          :class="classes.bar"
+          :style="bar.styles"
+          @click="() => onBarClick(bar)"
+        />
       </slot>
     </template>
   </div>
@@ -24,6 +29,10 @@
     options?: MiniHistogramOptions,
   }>()
 
+  const emit = defineEmits<{
+    (event: 'barClick', value: MiniHistogramBar): void,
+  }>()
+
   const { value: theme } = useColorTheme()
 
   const chart = ref<Element>()
@@ -37,6 +46,17 @@
     colorEnd: '#034efc',
     ...props.options,
   }))
+
+  const classes = computed(() => {
+    return {
+      root: {
+        'mini-histogram--clickable-bars': props.options?.clickable,
+      },
+      bar: {
+        'mini-histogram__bar--clickable': props.options?.clickable,
+      },
+    }
+  })
 
   const minDate = computed<Date>(() => {
     if (props.options?.startDate) {
@@ -113,6 +133,12 @@
 
     return { ...point, styles }
   }
+
+  function onBarClick(bar: MiniHistogramBar): void {
+    if (props.options?.clickable) {
+      emit('barClick', bar)
+    }
+  }
 </script>
 
 <style>
@@ -120,6 +146,10 @@
   relative
   min-h-[theme('spacing.5')]
   overflow-hidden
+}
+
+.mini-histogram--clickable-bars { @apply
+  py-4
 }
 
 .mini-histogram::before {
@@ -137,5 +167,18 @@
   bottom-0
   absolute
   rounded-sm
+}
+
+.mini-histogram__bar--clickable { @apply
+  top-1
+  bottom-1
+  cursor-pointer
+}
+.mini-histogram__bar--clickable:hover { @apply
+  shadow-lg
+  scale-125
+  origin-center
+  outline-8
+  z-10
 }
 </style>

--- a/src/components/MiniHistogram/MiniHistogram.vue
+++ b/src/components/MiniHistogram/MiniHistogram.vue
@@ -163,8 +163,8 @@
 }
 
 .mini-histogram__bar { @apply
-  top-0
-  bottom-0
+  top-[10%]
+  bottom-[10%]
   absolute
   rounded-sm
 }
@@ -176,7 +176,7 @@
 }
 .mini-histogram__bar--clickable:hover { @apply
   shadow-lg
-  scale-125
+  scale-[1.2]
   origin-center
   outline-8
   z-10

--- a/src/components/MiniHistogram/types.ts
+++ b/src/components/MiniHistogram/types.ts
@@ -8,6 +8,7 @@ export type MiniHistogramOptions = {
   endDate?: Date,
   minValue?: number,
   maxValue?: number,
+  clickable?: boolean,
 }
 
 export type MiniHistogramBar = HistogramDataPoint & {


### PR DESCRIPTION
Adds the ability to click bars on the mini histogram.

Note that in order to support the hover effect, some spacing needed to be accommodated for while retaining the `overflow: hidden;`. You can see how scale is being used to indicate hovering in the preview or here:

https://user-images.githubusercontent.com/6776415/234294345-5f543bf4-354b-4f2d-84b7-06773938e87d.mov

