### PR TITLE
Enhancement: LineChart `roundUpMaxValue` option and fix path js errors

### DIFF
--- a/src/components/LineChart/LineChart.vue
+++ b/src/components/LineChart/LineChart.vue
@@ -93,7 +93,11 @@
 
     const max = Math.max(...values.value, 0)
 
-    return roundUpToIncrement(max)
+    if (props.options?.roundUpMaxValue) {
+      return roundUpToIncrement(max)
+    }
+
+    return max
   })
 
   const yScale = computed(() => {
@@ -107,7 +111,7 @@
 
   const positions = computed<PointPosition[]>(() => data.value.map(([x, y]) => [xScale.value(x), yScale.value(y)]))
 
-  const strokePath = computed<string>(() => {
+  const strokePath = computed<string | null>(() => {
     const line = d3Line()
 
     if (props.options?.curve) {
@@ -116,10 +120,14 @@
       line.curve(curve)
     }
 
-    return line(positions.value) ?? ''
+    return line(positions.value)
   })
 
-  const fillPath = computed<string>(() => {
+  const fillPath = computed<string | null>(() => {
+    if (!strokePath.value) {
+      return null
+    }
+
     const [min, max] = xScale.value.range()
     const [first] = positions.value.at(0) ?? [min]
     const [last] = positions.value.at(-1) ?? [max]

--- a/src/components/LineChart/LineChart.vue
+++ b/src/components/LineChart/LineChart.vue
@@ -19,8 +19,8 @@
           <stop offset="100%" class="line-chart__gradient-stop" />
         </linearGradient>
       </defs>
-      <path class="line-chart__path" :d="strokePath" />
-      <path class="line-chart__fill" :d="fillPath" />
+      <path v-if="strokePath" class="line-chart__path" :d="strokePath" />
+      <path v-if="fillPath" class="line-chart__fill" :d="fillPath" />
     </svg>
   </div>
 </template>

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -7,6 +7,7 @@ export type LineChartOptions = {
   minValue?: number,
   maxValue?: number,
   curve?: Curve | CurveFactory,
+  roundUpMaxValue?: boolean,
 }
 
 export type LineChartDataPoint = [x: Date, y: number]


### PR DESCRIPTION
# Description
Fixes these errors 
<img width="521" alt="image" src="https://github.com/PrefectHQ/vue-charts/assets/6200442/95545bd0-628b-4cc2-b51f-27ebaa678a5a">

And adds an option for rounding up the max value which currently happens all the time by default. Technically a breaking change but we're only using this chart in one other place and I will update that chart to add the new option. 